### PR TITLE
fix title fallback value

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,7 +12,7 @@ export default function Home() {
   async function createPoll(formData: FormData) {
     "use server";
 
-    const title = formData.get("title")?.toString() ?? "Anonymous poll";
+    const title = formData.get("title")?.toString() || "Anonymous poll";
     const options: string[] = [];
 
     for (const [key, value] of formData.entries()) {


### PR DESCRIPTION
Even though we check the title length with `const canSubmit = title.length > 0` in `components/PollMaker.tsx`, I found that, if we don't have that condition check, it doesn't fall back to the default "Anonymous poll" value. 

Even though it's not a problem right now(because of the length check), it might become an issue if someone wants to add another form field that's optional, and it won't use the default value since the nullish coalescing operator (??) will only use the default value if the left operand is null or undefined, not for an empty string.

What are your thought on this?